### PR TITLE
Update rna-transcription.md

### DIFF
--- a/notes/rust/rna-transcription.md
+++ b/notes/rust/rna-transcription.md
@@ -2,36 +2,40 @@ Congratulations on passing all the tests!
 
  * I like this solution is succinct and readable, with almost-always
    informative names for the bindings.
- * I like that you derive the `PartialEq` on `DNA` and `RNA` instead if
+ * I like that you derive the `PartialEq` on `Dna` and `Rna` instead if
    implementing it manually.
 
 One thing I noticed was:
 
 ```rust
 #[derive(Debug, PartialEq)]
-pub struct DNA(String);
+pub struct Dna(String);
 ```
 
 which leaves referring to the struct field as if it were a tuple, for example:
 
 ```rust
-RNA(self.0.chars()...
+Rna(self.0.chars()...
 ```
 
 which makes it less informative, as if it were a magic number, when it doesn't
 have to be.
 
 Something to consider is that the logic needed to create correct values in the
-`new` methods would be bypassed if someone were to create DNA or RNA as a struct
+`new` methods would be bypassed if someone were to create Dna or Rna as a struct
 literal, for example:
 
 ```rust
-let my_DNA = DNA {0: "ACGT"};
+let my_Dna = Dna {0: "ACGT"};
 ```
 
 Ways to prevent the creation of a struct literal are described in [this article
 by Steve
 Klabnik](https://steveklabnik.com/writing/structure-literals-vs-constructors-in-rust).
 I think what he suggests wouldn't pass the tests, since the tests don't call
-DNA/RNA nested inside another modular scope, but it would be a good thing to
-consider if making your own library for other people to use.
+Dna/Rna nested inside another modular scope, but it would be a good thing to
+consider if making your own library for other people to use. As the author writes: 
+"To me, understanding things like this is when I really start to feel like I’m getting
+to know a language: putting three or four disparate concepts together to achieve some 
+goal. It’s when a language stops being a bunch of disjoint parts and starts becoming 
+a cohesive whole."


### PR DESCRIPTION
Solution was updated to case-change DNA to Dna and RNA to Rna. Also added a note to emphasize the reason for the article, as several students for Clock responded that they couldn't create a struct literal in Clock anyway.