### PR TITLE
Implement stack resolver override for Haskell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ The usual workflow is as such:
 
 ### Haskell
 
-You can optionally override student's resolver by setting `XR_HASKELL_STACK_RESOLVER` to a valid resolver version.
-(e.g. `XR_HASKELL_STACK_RESOLVER=lts-16.21 xr t`)
+You can optionally override a student iteration's resolver by setting
+`XR_HASKELL_STACK_RESOLVER` to a valid resolver version, for example
+`XR_HASKELL_STACK_RESOLVER=lts-16.21 xr t`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ The usual workflow is as such:
  * When done for the day, you may run `xr clean` in order to remove all
    downloaded exercise submissions.
 
+## Track-specific settings
+
+### Haskell
+
+You can optionally override student's resolver by setting `XR_HASKELL_STACK_RESOLVER` to a valid resolver version.
+(e.g. `XR_HASKELL_STACK_RESOLVER=lts-16.21 xr t`)
 
 ## Contributing
 

--- a/tracks/haskell.sh
+++ b/tracks/haskell.sh
@@ -5,7 +5,7 @@ function _override_stack_resolver() {
 
     # See https://docs.haskellstack.org/en/stable/pantry/#snapshot-location for resolver syntax.
     # For the purpose of running exercises it's resonable just to allow lts and nightly.
-    if ! [[ $XR_HASKELL_STACK_RESOLVER =~ '^(lts-[0-9\.]+|nightly-[0-9-]+)$' ]]; then
+    if ! [[ "$XR_HASKELL_STACK_RESOLVER" =~ ^(lts-[0-9\.]+|nightly-[0-9-]+)$ ]]; then
         echo Skipped resolver override as $XR_HASKELL_STACK_RESOLVER is not allowed.
         return
     fi

--- a/tracks/haskell.sh
+++ b/tracks/haskell.sh
@@ -10,7 +10,7 @@ function _override_stack_resolver() {
         return
     fi
 
-    if ! stack --resolver="$XR_HASKELL_STACK_RESOLVER" eval '()' >/dev/null 2>/dev/null; then
+    if ! stack --resolver="$XR_HASKELL_STACK_RESOLVER" eval '()' 2>&1 >/dev/null; then
         echo Skipped resolver override as stack cannot recognize $XR_HASKELL_STACK_RESOLVER.
         return
     fi

--- a/tracks/haskell.sh
+++ b/tracks/haskell.sh
@@ -3,8 +3,9 @@ function _override_stack_resolver() {
         return
     fi
 
-    # See https://docs.haskellstack.org/en/stable/pantry/#snapshot-location for resolver syntax.
-    # For the purpose of running exercises it's resonable just to allow lts and nightly.
+    # See https://docs.haskellstack.org/en/stable/pantry/#snapshot-location for
+    # the resolver syntax. For the purpose of running exercises, it's reasonable
+    # just to allow LTS and nightly.
     if ! [[ "$XR_HASKELL_STACK_RESOLVER" =~ ^(lts-[0-9\.]+|nightly-[0-9-]+)$ ]]; then
         echo Skipped resolver override as $XR_HASKELL_STACK_RESOLVER is not allowed.
         return

--- a/tracks/haskell.sh
+++ b/tracks/haskell.sh
@@ -1,10 +1,33 @@
+function _override_stack_resolver() {
+    if [[ -z "$XR_HASKELL_STACK_RESOLVER" ]]; then
+        return
+    fi
+
+    # See https://docs.haskellstack.org/en/stable/pantry/#snapshot-location for resolver syntax.
+    # For the purpose of running exercises it's resonable just to allow lts and nightly.
+    if ! [[ $XR_HASKELL_STACK_RESOLVER =~ '^(lts-[0-9\.]+|nightly-[0-9-]+)$' ]]; then
+        echo Skipped resolver override as $XR_HASKELL_STACK_RESOLVER is not allowed.
+        return
+    fi
+
+    if ! stack --resolver="$XR_HASKELL_STACK_RESOLVER" eval '()' >/dev/null 2>/dev/null; then
+        echo Skipped resolver override as stack cannot recognize $XR_HASKELL_STACK_RESOLVER.
+        return
+    fi
+
+    echo Overriding resolver to $XR_HASKELL_STACK_RESOLVER.
+    sed -i 's/resolver: .*/resolver: '"$XR_HASKELL_STACK_RESOLVER"'/' stack.yaml
+}
+
 # Runs all the available tests.
 function _run_tests() {
-    stack test -Wall --trace \
+    _override_stack_resolver
+    stack test --ghc-options -Wall \
         && hlint .
 }
 
 # Just runs any available benchmark, importing still needs to be added.
 function _run_benches() {
-    stack bench -Wall --no-run-tests
+    _override_stack_resolver
+    stack bench --ghc-options -Wall --no-run-tests
 }

--- a/tracks/haskell.sh
+++ b/tracks/haskell.sh
@@ -28,6 +28,6 @@ function _run_tests() {
 
 # Just runs any available benchmark, importing still needs to be added.
 function _run_benches() {
-    _override_stack_resolver
-    stack bench --ghc-options -Wall --no-run-tests
+    _override_stack_resolver \
+        && stack bench --ghc-options -Wall --no-run-tests
 }

--- a/tracks/haskell.sh
+++ b/tracks/haskell.sh
@@ -21,8 +21,8 @@ function _override_stack_resolver() {
 
 # Runs all the available tests.
 function _run_tests() {
-    _override_stack_resolver
-    stack test --ghc-options -Wall \
+    _override_stack_resolver \
+        && stack test --ghc-options -Wall \
         && hlint .
 }
 


### PR DESCRIPTION
Closes #13.

Sorry I forgot I have some other local changes, which is not related to #13, but this probably doesn't worth having a separated PR, in particular:

- `-Wall` to `--ghc-options -Wall` as this is supposed to be pased to GHC (stack can't recognize this flag)
- Removed `--trace` as it tends to be verbose and messes up hspec's output.